### PR TITLE
Components revamp

### DIFF
--- a/components/component_example_list.js
+++ b/components/component_example_list.js
@@ -169,16 +169,16 @@ function label(text, orientation) {
     return new Plottable.Component.Label(text, orientation);
 }
 
+function titleLabel(text, orientation) {
+    return new Plottable.Component.TitleLabel(text, orientation);
+}
+
 function legend() {
-    var colorScale = new Plottable.Scale.Color("category10");
+    var colorScale = new Plottable.Scale.Color();
     var legend = new Plottable.Component.Legend(colorScale);
-    legend.toggleCallback(function () {
-        return;
-    }); // empty function, just to turn toggling on
-    legend.hoverCallback(function () {
-        return;
-    });
     legend.scale().domain(ordinalDomain);
+    legend.maxEntriesPerRow(1);
+    legend.xAlign("center");
     return legend;
 }
 
@@ -187,10 +187,7 @@ function gridline(showVertical, showHorizontal) {
     var yScale = new Plottable.Scale.Linear();
 
     var gridlines = new Plottable.Component.Gridlines(showVertical ? xScale : null, showHorizontal ? yScale : null);
-    var xAxis = new Plottable.Axis.Numeric(xScale, "bottom");
-    var yAxis = new Plottable.Axis.Numeric(yScale, "left");
-    var table = new Plottable.Component.Table([[yAxis, gridlines], [null, xAxis]]);
-    return table;
+    return gridlines;
 }
 
 function animate1() {

--- a/components/component_example_list.js
+++ b/components/component_example_list.js
@@ -177,7 +177,6 @@ function legend() {
     var colorScale = new Plottable.Scale.Color();
     var legend = new Plottable.Component.Legend(colorScale);
     legend.scale().domain(ordinalDomain);
-    legend.maxEntriesPerRow(1);
     legend.xAlign("center");
     return legend;
 }

--- a/components/index.html
+++ b/components/index.html
@@ -10,7 +10,7 @@ page_id : page-components
 The best way to think about Plottable that you will not be rendering plots, but you will be rendering components or tables of components.  Even a plot is considered a component!<br><br>
 By thinking in this manner, one can imagine that any component can be dropped into any cell of a table, meaning you have flexibility on where components go in relation to other components.<br><br>
 
-Below are a variety of components you can choose from to place onto your Plottable table.
+Below are some of the components you can choose from to place onto your Plottable tables.
 </div>
 
 

--- a/components/index.html
+++ b/components/index.html
@@ -134,65 +134,45 @@ window.onload = function() {
                                              [null, null, xLabel, null, null]]);
   table.renderTo("#plot-table");
 
-  var horizLineLength = d3.select("#plot-table").attr("width");
-  var vertLineLength = d3.select("#plot-table").attr("height");
-  window.test1 = horizLineLength;
-  window.test2 = vertLineLength;
-
-  d3.select("#plot-table").append("line").attr({x1: 0, x2: 0, y1: 0, y2: vertLineLength, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: yAxis1._xOrigin, x2: yAxis1._xOrigin, y1: 0, y2: vertLineLength, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: barPlot0._xOrigin, x2: barPlot0._xOrigin, y1: 0, y2: vertLineLength, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: yAxis0._xOrigin, x2: yAxis0._xOrigin, y1: 0, y2: vertLineLength, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: yLabel0._xOrigin, x2: yLabel0._xOrigin, y1: 0, y2: vertLineLength, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: horizLineLength, x2: horizLineLength, y1: 0, y2: vertLineLength, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: 0, y2: 0, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: barPlot0._yOrigin, y2: barPlot0._yOrigin, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: barPlot1._yOrigin, y2: barPlot1._yOrigin, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: xAxis._yOrigin, y2: xAxis._yOrigin, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: xLabel._yOrigin, y2: xLabel._yOrigin, stroke: "black"});
-  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: vertLineLength, y2: vertLineLength, stroke: "black"});
-
+  var widths = [yLabel1.width(), yAxis1.width(), xAxis.width(), yAxis0.width(), yLabel0.width()];
+  var heights = [masterLabel.height(), yAxis0.height(), yAxis1.height(), xAxis.height(), xLabel.height()];
+  var combos = [];
+  for (var i = 0; i < 5; i++) {
+	for (var j = 0; j < 5; j++) {
+      combos.push([widths[j], heights[i]]);
+	}
+  }
+  var cells = d3.select("#plot-table").selectAll(".website-table-cells").data(combos);
+  cells.enter().append("rect").classed("website-table-cells", true);
+  cells.exit().remove();
+  cells.attr("stroke", "black")
+       .attr("opacity", "0.3")
+       .attr("width", function(d) { return d[0];})
+       .attr("height", function(d) { return d[1];})
+       .attr("x", function(d, i) { return Math.max(0, d3.sum(widths.slice(0, i % 5)));})
+       .attr("y", function(d, i) { return Math.max(0, d3.sum(heights.slice(0, Math.floor(i / 5))));})
+       .attr("id", function(d, i) { return "websiteTableCell-" + i % 5 + "-" + Math.floor(i / 5); })
+       .each(function(d) { $(this).qtip({content: "null", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});; });
   var colorScale = new Plottable.Scale.Color();
-  var opacity = "0.3";
-  xAxis.foreground().append("rect")
-                    .attr({stroke: "black", fill: colorScale.range()[0], width: xAxis.width(), height: xAxis.height(), opacity: opacity, id: "tableXAxis"});
-  $("#tableXAxis").qtip({content: "new Plottable.Axis.Linear(xScale, \"bottom\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  yAxis0.foreground().append("rect")
-                     .attr({fill: colorScale.range()[1], width: yAxis0.width(), height: yAxis0.height(), opacity: opacity, id: "tableYAxis0"});
-  $("#tableYAxis0").qtip({content: "new Plottable.Axis.Linear(yScale0, \"right\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  yAxis1.foreground().append("rect")
-                     .attr({fill: colorScale.range()[2], width: yAxis1.width(), height: yAxis1.height(), opacity: opacity, id: "tableYAxis1"});
-  $("#tableYAxis1").qtip({content: "new Plottable.Axis.Linear(yScale1, \"left\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  barPlot0.foreground().append("rect")
-                       .attr({fill: colorScale.range()[3], width: barPlot0.width(), height: barPlot0.height(), opacity: opacity, id: "tableBarPlot0"});
-  $("#tableBarPlot0").qtip({content: "new Plottable.Plot.Bar(xScale, yScale0)", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  barPlot1.foreground().append("rect")
-                       .attr({fill: colorScale.range()[4], width: barPlot1.width(), height: barPlot1.height(), opacity: opacity, id: "tableBarPlot1"});
-  $("#tableBarPlot1").qtip({content: "new Plottable.Plot.Bar(xScale, yScale1)", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
 
-  // Labels don't take up their entire cell
-  d3.select("#plot-table").append("rect")
-                          .attr({x: yLabel0._xOrigin, y: yAxis0._yOrigin, width: yLabel0.width(), height: yAxis0.height(), fill: colorScale.range()[5], opacity: opacity, id: "tableYLabel0"});
-  $("#tableYLabel0").qtip({content: "new Plottable.Component.Label(\"Top\", \"right\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  d3.select("#plot-table").append("rect")
-                          .attr({x: yLabel1._xOrigin, y: yAxis1._yOrigin, width: yLabel1.width(), height: yAxis1.height(), fill: colorScale.range()[6], opacity: opacity, id: "tableYLabel1"});
-  $("#tableYLabel1").qtip({content: "new Plottable.Component.Label(\"Bottom\", \"left\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  d3.select("#plot-table").append("rect")
-                          .attr({x: xAxis._xOrigin, y: xLabel._yOrigin, width: xAxis.width(), height: xLabel.height(), fill: colorScale.range()[7], opacity: opacity, id: "tableXLabel"});
-  $("#tableXLabel").qtip({content: "new Plottable.Component.Label(\"Categories\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  d3.select("#plot-table").append("rect")
-                          .attr({x: xAxis._xOrigin, y: masterLabel._yOrigin, width: xAxis.width(), height: masterLabel.height(), fill: colorScale.range()[8], opacity: opacity, id: "tableTitleLabel"});
-  $("#tableTitleLabel").qtip({content: "new Plottable.Component.TitleLabel(\"MasterLabel\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#websiteTableCell-2-0").attr("fill", colorScale.range()[0])
+                             .qtip({content: "new Plottable.Component.TitleLabel(\"The Master Plot\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#websiteTableCell-2-1").attr("fill", colorScale.range()[1])
+                             .qtip({content: "new Plottable.Plot.Bar(xScale, yScale0)", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#websiteTableCell-3-1").attr("fill", colorScale.range()[2])
+                             .qtip({content: "new Plottable.Axis.Linear(yScale0, \"right\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#websiteTableCell-4-1").attr("fill", colorScale.range()[3])
+                             .qtip({content: "new Plottable.Component.Label(\"Top\", \"right\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#websiteTableCell-0-2").attr("fill", colorScale.range()[4])
+                             .qtip({content: "new Plottable.Component.Label(\"Bottom\", \"left\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#websiteTableCell-1-2").attr("fill", colorScale.range()[5])
+                             .qtip({content: "new Plottable.Axis.Linear(yScale1, \"left\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#websiteTableCell-2-2").attr("fill", colorScale.range()[6])
+                             .qtip({content: "new Plottable.Plot.Bar(xScale, yScale1)", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#websiteTableCell-2-3").attr("fill", colorScale.range()[7])
+                             .qtip({content: "new Plottable.Axis.Linear(xScale, \"bottom\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#websiteTableCell-2-4").attr("fill", colorScale.range()[8])
+                             .qtip({content: "new Plottable.Component.Label(\"Categories\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
 
-//Attach tooltips with qTip2 (which uses the "title" attribute by default)
-  $("#plot-table").qtip({
-    position : {
-      my : "bottom middle",
-      at : "top middle"
-    },
-    style : {
-      classes : "qtip-dark"
-    }
-  });
 }
 </script>

--- a/components/index.html
+++ b/components/index.html
@@ -70,10 +70,24 @@ Below are a variety of components you can choose from to place onto your Plottab
 <div class="container">
   <h2>Placing Components Into the Plottable Table</h2>
   With the components above, you should be able to lay out the components you want into whatever table layout you may wish.<br><br>
-  Below is a pretty complex layout which uses a 5x5 table with each cell containing either a component (if it contains a component) or null.<br>
-  Due to the nature of treating every object as a component, even complex layouts like the one below are not terribly difficult.
-  All you need to do is grab each component and then lay them out onto a 5x5 array.
-  <svg id="plot-table" height="300"></svg>
+  Let's assume that you want a really simply chart, one that has an axis for the y dimenstion, one for the x dimension, and a bar plot to visualize the data you have.<br>
+  Looking at the component list above, you can find that each axis can be just considered as a componant, and the bar plot as well is just a component.
+  Thus, below shows a table that can achieve this layout.<br>
+  <svg id="simple-plot-table" height="300"></svg><br><br>
+  However, let's say that the chart you want is a lot more complex.<br><br>
+  Let's say that you want to place a title at the top of the chart.<br>
+  Also, let's say that instead of a single plot, you want two, where one is laid above the other.<br>
+  In accordance, maybe you want two axes for the y dimension, one for each plot, but you want the axis for the top plot to be to the right of the plot and the bottom plot's axis to be to the left.<br>
+  Maybe it would be nice to also add labels for the axes as well...<br><br>
+  Well that got complex real fast!<br><br>
+  Luckily, if you again think of each item as a component and think about how this layout would look in a table, it is not difficult to achieve the above goal.<br><br>
+  Instead of having one bar plot component, you will need two.<br>
+  Also, instead of having two axes components, you will need to add another one for the additional axis on the y dimension.<br><br>
+  Now, the only thing we need left is to add labels for the axes and the chart itself.<br>
+  However, if you sift through the above, you can find that there is a Label component for the axes and a TitleLabel component for the entire chart.<br>
+  Thus, you just need two of the Label components and a single TitleLabel component.<br><br>
+  Now that you have all of our components, all you need to do now is lay them out.  The below 5x5 layout achieves the above goal.
+  <svg id="complex-plot-table" height="300"></svg>
 </div>
 
 <script src="component_example_list.js"></script>
@@ -107,6 +121,46 @@ window.onload = function() {
     }
   });
 
+  var simpleData = [{x: "First", y: 5}, {x: "Second", y: 10}, {x: "Third", y: 14}];
+  var simpleXScale = new Plottable.Scale.Ordinal();
+  var simpleYScale = new Plottable.Scale.Linear();
+  var simpleXAxis = new Plottable.Axis.Category(simpleXScale, "bottom");
+  var simpleYAxis = new Plottable.Axis.Numeric(simpleYScale, "left");
+  var simpleBarPlot = new Plottable.Plot.Bar(simpleXScale, simpleYScale)
+                                        .addDataset(simpleData)
+                                        .project("x", "x", simpleXScale)
+                                        .project("y", "y", simpleYScale);
+  var simpleChartTable = new Plottable.Component.Table([[simpleYAxis, simpleBarPlot],
+                                                  [null, simpleXAxis]]);
+  simpleChartTable.renderTo("#simple-plot-table");
+
+  var simpleWidths = [simpleYAxis.width(), simpleXAxis.width()];
+  var simpleHeights = [simpleYAxis.height(), simpleXAxis.height()];
+  var combos = [];
+  for (var i = 0; i < 2; i++) {
+    for (var j = 0; j < 2; j++) {
+      combos.push([simpleWidths[j], simpleHeights[i]]);
+    }
+  }
+  var cells = d3.select("#simple-plot-table").selectAll(".website-table-cells").data(combos);
+  cells.enter().append("rect").classed("website-table-cells", true);
+  cells.exit().remove();
+  cells.attr("stroke", "black")
+       .attr("opacity", "0.3")
+       .attr("width", function(d) { return d[0];})
+       .attr("height", function(d) { return d[1];})
+       .attr("x", function(d, i) { return Math.max(0, d3.sum(simpleWidths.slice(0, i % 2)));})
+       .attr("y", function(d, i) { return Math.max(0, d3.sum(simpleHeights.slice(0, Math.floor(i / 2))));})
+       .attr("id", function(d, i) { return "simpleTableCell-" + i % 2 + "-" + Math.floor(i / 2); })
+       .each(function(d) { $(this).qtip({content: "null", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});; });
+  var colorScale = new Plottable.Scale.Color();
+  $("#simpleTableCell-0-0").attr("fill", colorScale.range()[0])
+                            .qtip({content: "new Plottable.Axis.Numeric(yScale, \"left\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#simpleTableCell-1-0").attr("fill", colorScale.range()[1])
+                            .qtip({content: "new Plottable.Plot.Bar(xScale, yScale)", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  $("#simpleTableCell-1-1").attr("fill", colorScale.range()[2])
+                            .qtip({content: "new Plottable.Axis.Category(xScale, \"bottom\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+
   var data0 = [{x: "A", y: 5}, {x: "B", y: 10}, {x: "C", y: 14}];
   var data1 = [{x: "A", y: 2}, {x: "B", y: 13}, {x: "C", y: 12}];
   var xScale = new Plottable.Scale.Ordinal();
@@ -132,7 +186,7 @@ window.onload = function() {
                                              [yLabel1, yAxis1, barPlot1, null, null],
                                              [null, null, xAxis, null, null],
                                              [null, null, xLabel, null, null]]);
-  table.renderTo("#plot-table");
+  table.renderTo("#complex-plot-table");
 
   var widths = [yLabel1.width(), yAxis1.width(), xAxis.width(), yAxis0.width(), yLabel0.width()];
   var heights = [masterLabel.height(), yAxis0.height(), yAxis1.height(), xAxis.height(), xLabel.height()];
@@ -142,7 +196,7 @@ window.onload = function() {
       combos.push([widths[j], heights[i]]);
 	}
   }
-  var cells = d3.select("#plot-table").selectAll(".website-table-cells").data(combos);
+  var cells = d3.select("#complex-plot-table").selectAll(".website-table-cells").data(combos);
   cells.enter().append("rect").classed("website-table-cells", true);
   cells.exit().remove();
   cells.attr("stroke", "black")
@@ -151,27 +205,27 @@ window.onload = function() {
        .attr("height", function(d) { return d[1];})
        .attr("x", function(d, i) { return Math.max(0, d3.sum(widths.slice(0, i % 5)));})
        .attr("y", function(d, i) { return Math.max(0, d3.sum(heights.slice(0, Math.floor(i / 5))));})
-       .attr("id", function(d, i) { return "websiteTableCell-" + i % 5 + "-" + Math.floor(i / 5); })
+       .attr("id", function(d, i) { return "complexTableCell-" + i % 5 + "-" + Math.floor(i / 5); })
        .each(function(d) { $(this).qtip({content: "null", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});; });
   var colorScale = new Plottable.Scale.Color();
 
-  $("#websiteTableCell-2-0").attr("fill", colorScale.range()[0])
+  $("#complexTableCell-2-0").attr("fill", colorScale.range()[0])
                              .qtip({content: "new Plottable.Component.TitleLabel(\"The Master Plot\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  $("#websiteTableCell-2-1").attr("fill", colorScale.range()[1])
+  $("#complexTableCell-2-1").attr("fill", colorScale.range()[1])
                              .qtip({content: "new Plottable.Plot.Bar(xScale, yScale0)", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  $("#websiteTableCell-3-1").attr("fill", colorScale.range()[2])
+  $("#complexTableCell-3-1").attr("fill", colorScale.range()[2])
                              .qtip({content: "new Plottable.Axis.Linear(yScale0, \"right\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  $("#websiteTableCell-4-1").attr("fill", colorScale.range()[3])
+  $("#complexTableCell-4-1").attr("fill", colorScale.range()[3])
                              .qtip({content: "new Plottable.Component.Label(\"Top\", \"right\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  $("#websiteTableCell-0-2").attr("fill", colorScale.range()[4])
+  $("#complexTableCell-0-2").attr("fill", colorScale.range()[4])
                              .qtip({content: "new Plottable.Component.Label(\"Bottom\", \"left\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  $("#websiteTableCell-1-2").attr("fill", colorScale.range()[5])
+  $("#complexTableCell-1-2").attr("fill", colorScale.range()[5])
                              .qtip({content: "new Plottable.Axis.Linear(yScale1, \"left\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  $("#websiteTableCell-2-2").attr("fill", colorScale.range()[6])
+  $("#complexTableCell-2-2").attr("fill", colorScale.range()[6])
                              .qtip({content: "new Plottable.Plot.Bar(xScale, yScale1)", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  $("#websiteTableCell-2-3").attr("fill", colorScale.range()[7])
+  $("#complexTableCell-2-3").attr("fill", colorScale.range()[7])
                              .qtip({content: "new Plottable.Axis.Linear(xScale, \"bottom\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
-  $("#websiteTableCell-2-4").attr("fill", colorScale.range()[8])
+  $("#complexTableCell-2-4").attr("fill", colorScale.range()[8])
                              .qtip({content: "new Plottable.Component.Label(\"Categories\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
 
 }

--- a/components/index.html
+++ b/components/index.html
@@ -70,8 +70,8 @@ Below are a variety of components you can choose from to place onto your Plottab
 <div class="container">
   <h2>Placing Components Into the Plottable Table</h2>
   With the components above, you should be able to lay out the components you want into whatever table layout you may wish.<br><br>
-  Let's assume that you want a really simply chart, one that has an axis for the y dimenstion, one for the x dimension, and a bar plot to visualize the data you have.<br>
-  Looking at the component list above, you can find that each axis can be just considered as a componant, and the bar plot as well is just a component.
+  Let's assume that you want a really simple chart, one that has an axis for the y dimenstion, one for the x dimension, and a bar plot to visualize the data you have.<br>
+  Looking at the component list above, you can find that each axis can be just considered as a component, and the bar plot as well is just a component.
   Thus, below shows a table that can achieve this layout.<br>
   <svg id="simple-plot-table" height="300"></svg><br><br>
   However, let's say that the chart you want is a lot more complex.<br><br>

--- a/components/index.html
+++ b/components/index.html
@@ -3,24 +3,57 @@ layout  : subpage
 page_id : page-components
 ---
 <div class="container">
-  <div class="row component-group">
-    <div class="col-md-12">
-      <h2>Axes</h2>
-      <svg id="table1" height="500"></svg>
-    </div>
-  </div>
+  <h2>The Component List</h2>
+The best way to think about Plottable that you will not be rendering plots, but you will be rendering components or tables of components.  Even a plot is considered a component!<br><br>
+By thinking in this manner, one can imagine that any component can be dropped into any cell of a table, meaning you have flexibility on where components go in relation to other components.<br><br>
+
+Below are a variety of components you can choose from to place onto your Plottable table.
+</div>
+
+
+<div class="container">
 
   <div class="row component-group">
     <div class="col-md-12">
       <h2>Plots</h2>
-      <svg id="table2" height="1500"></svg>
+      <h3>Bar Plot</h3>
+      <div border="2px solid"><svg id="barPlot" height="250"></svg></div>
+
+      <h3>Line Plot</h3>
+      <svg id="linePlot" height="250"></svg>
+      <h3>Area Plot</h3>
+      <svg id="areaPlot" height="250"></svg>
+      <h3>Scatter</h3>
+      <svg id="scatterPlot" height="250"></svg>
     </div>
   </div>
 
   <div class="row component-group">
     <div class="col-md-12">
-      <h2>Gridlines</h2>
-      <svg id="table3" height="300"></svg>
+      <h2>Axes</h2>
+      <h3>Numeric Axis</h3>
+      <svg id="numericAxis" height="50"></svg>
+      <h3>Category Axis</h3>
+      <svg id="categoryAxis" height="50"></svg>
+      <h3>Time Axis</h3>
+      <svg id="timeAxis" height="50"></svg>
+    </div>
+  </div>
+
+  <div class="row component-group">
+    <div class="col-md-12">
+      <h2>Labels</h2>
+      <h3>Regular Label</h3>
+      <svg id="label" height="50"></svg>
+      <h3>Title Label</h3>
+      <svg id="titleLabel" height="50"></svg>
+    </div>
+  </div>
+
+  <div class="row component-group">
+    <div class="col-md-12">
+      <h2>Legends</h2>
+      <svg id="legend" height="50"></svg>
     </div>
   </div>
 </div>
@@ -28,64 +61,21 @@ page_id : page-components
 <script src="component_example_list.js"></script>
 <script>
 window.onload = function() {
-  // axis
-  var axisTypes = ["numeric", "time", "category"];
-  var orient = ["top", "left", "bottom", "right"];
-  var x = [0, 1, 2, 1];
-  var y = [1, 0, 1, 2];
 
-  var table = new Plottable.Component.Table();
-  var innerTable = new Plottable.Component.Table();
-  axisTypes.forEach(function(type, index1) {
-    orient.forEach(function(or, index2) {
-      if (type === "time" && (or === "left" || or === "right" || or === "top")) {
-        return; // unsupported for now
-      }
-      var component = axis(type, or);
-      innerTable.addComponent(x[index2] + index1 * 3, y[index2], component);
-    })
-  });
-  table.addComponent(1, 0, innerTable);
-  table.renderTo("#table1");
+  // axis
+  axis("numeric", "bottom").renderTo("#numericAxis");
+  axis("category", "bottom").renderTo("#categoryAxis");
+  axis("time", "bottom").renderTo("#timeAxis");
 
   // plots
-  var innerTable2 = new Plottable.Component.Table();
-  innerTable2.addComponent(0, 1, verticalBarPlot());
-  innerTable2.addComponent(0, 2, horizontalBarPlot());
+  verticalBarPlot().renderTo("#barPlot");
+  makeXYPlot("line").renderTo("#linePlot");
+  makeXYPlot("area").renderTo("#areaPlot");
+  makeXYPlot("scatter").renderTo("#scatterPlot");
 
-  var xyPlotTypes = ["area", "line", "scatter"];
-  xyPlotTypes.forEach(function(type, index) {
-    innerTable2.addComponent(index + 1, 1, makeXYPlot(type));
-  });
+  label("Hello world!", "horizontal").renderTo("#label");
+  titleLabel("Hello world!", "horizontal").renderTo("#titleLabel");
 
-  xyPlotTypes.forEach(function(type, index) {
-    innerTable2.addComponent(index + 1, 2, makeXYPlotMulti(type));
-  });
-
-  innerTable2.addComponent(4, 1, gridPlot());
-  innerTable2.addComponent(0, 0, makeTitle("bar"));
-  innerTable2.addComponent(1, 0, makeTitle("area"));
-  innerTable2.addComponent(2, 0, makeTitle("line"));
-  innerTable2.addComponent(3, 0, makeTitle("scatter"));
-  innerTable2.addComponent(4, 0, makeTitle("grid"));
-
-  var table2 = new Plottable.Component.Table();
-  table2.addComponent(1, 1, innerTable2);
-  table2.renderTo("#table2");
-
-  var clickInteraction = new Plottable.Interaction.Click(table2).callback(function() {table2.renderTo("#table2")})
-  table2.registerInteraction(clickInteraction);
-
-  // gridlines
-  var innerTable3 = new Plottable.Component.Table();
-  var showx = [true, false, true];
-  var showy = [false, true, true];
-  for (var i = 0; i < 3; i++) {
-    innerTable3.addComponent(0, i, gridline(showx[i], showy[i]));
-  }
-
-  var table3 = new Plottable.Component.Table();
-  table3.addComponent(1, 1, innerTable3);
-  table3.renderTo("#table3");
+  legend().renderTo("#legend");
 }
 </script>

--- a/components/index.html
+++ b/components/index.html
@@ -67,6 +67,15 @@ Below are a variety of components you can choose from to place onto your Plottab
   </div>
 </div>
 
+<div class="container">
+  <h2>Placing Components Into the Plottable Table</h2>
+  With the components above, you should be able to lay out the components you want into whatever table layout you may wish.<br><br>
+  Below is a pretty complex layout which uses a 5x5 table with each cell containing either a component (if it contains a component) or null.<br>
+  Due to the nature of treating every object as a component, even complex layouts like the one below are not terribly difficult.
+  All you need to do is grab each component and then lay them out onto a 5x5 array.
+  <svg id="plot-table" height="300"></svg>
+</div>
+
 <script src="component_example_list.js"></script>
 <script>
 window.onload = function() {
@@ -89,6 +98,94 @@ window.onload = function() {
 
   //Attach tooltips with qTip2 (which uses the "title" attribute by default)
   $("svg").qtip({
+    position : {
+      my : "bottom middle",
+      at : "top middle"
+    },
+    style : {
+      classes : "qtip-dark"
+    }
+  });
+
+  var data0 = [{x: "A", y: 5}, {x: "B", y: 10}, {x: "C", y: 14}];
+  var data1 = [{x: "A", y: 2}, {x: "B", y: 13}, {x: "C", y: 12}];
+  var xScale = new Plottable.Scale.Ordinal();
+  var yScale0 = new Plottable.Scale.Linear();
+  var yScale1 = new Plottable.Scale.Linear();
+  var xAxis = new Plottable.Axis.Category(xScale, "bottom");
+  var yAxis0 = new Plottable.Axis.Numeric(yScale0, "right");
+  var yAxis1 = new Plottable.Axis.Numeric(yScale1, "left");
+  var barPlot0 = new Plottable.Plot.Bar(xScale, yScale0)
+                                   .addDataset(data0)
+                                   .project("x", "x", xScale)
+                                   .project("y", "y", yScale0);
+  var barPlot1 = new Plottable.Plot.Bar(xScale, yScale1)
+                                   .addDataset(data1)
+                                   .project("x", "x", xScale)
+                                   .project("y", "y", yScale1);
+  var yLabel0 = new Plottable.Component.Label("Top", "right");
+  var yLabel1 = new Plottable.Component.Label("Bottom", "left");
+  var xLabel = new Plottable.Component.Label("Categories");
+  var masterLabel = new Plottable.Component.TitleLabel("The Master Plot");
+  var table = new Plottable.Component.Table([[null, null, masterLabel, null, null],
+                                             [null, null, barPlot0, yAxis0, yLabel0],
+                                             [yLabel1, yAxis1, barPlot1, null, null],
+                                             [null, null, xAxis, null, null],
+                                             [null, null, xLabel, null, null]]);
+  table.renderTo("#plot-table");
+
+  var horizLineLength = d3.select("#plot-table").attr("width");
+  var vertLineLength = d3.select("#plot-table").attr("height");
+  window.test1 = horizLineLength;
+  window.test2 = vertLineLength;
+
+  d3.select("#plot-table").append("line").attr({x1: 0, x2: 0, y1: 0, y2: vertLineLength, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: yAxis1._xOrigin, x2: yAxis1._xOrigin, y1: 0, y2: vertLineLength, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: barPlot0._xOrigin, x2: barPlot0._xOrigin, y1: 0, y2: vertLineLength, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: yAxis0._xOrigin, x2: yAxis0._xOrigin, y1: 0, y2: vertLineLength, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: yLabel0._xOrigin, x2: yLabel0._xOrigin, y1: 0, y2: vertLineLength, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: horizLineLength, x2: horizLineLength, y1: 0, y2: vertLineLength, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: 0, y2: 0, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: barPlot0._yOrigin, y2: barPlot0._yOrigin, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: barPlot1._yOrigin, y2: barPlot1._yOrigin, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: xAxis._yOrigin, y2: xAxis._yOrigin, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: xLabel._yOrigin, y2: xLabel._yOrigin, stroke: "black"});
+  d3.select("#plot-table").append("line").attr({x1: 0, x2: horizLineLength, y1: vertLineLength, y2: vertLineLength, stroke: "black"});
+
+  var colorScale = new Plottable.Scale.Color();
+  var opacity = "0.3";
+  xAxis.foreground().append("rect")
+                    .attr({stroke: "black", fill: colorScale.range()[0], width: xAxis.width(), height: xAxis.height(), opacity: opacity, id: "tableXAxis"});
+  $("#tableXAxis").qtip({content: "new Plottable.Axis.Linear(xScale, \"bottom\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  yAxis0.foreground().append("rect")
+                     .attr({fill: colorScale.range()[1], width: yAxis0.width(), height: yAxis0.height(), opacity: opacity, id: "tableYAxis0"});
+  $("#tableYAxis0").qtip({content: "new Plottable.Axis.Linear(yScale0, \"right\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  yAxis1.foreground().append("rect")
+                     .attr({fill: colorScale.range()[2], width: yAxis1.width(), height: yAxis1.height(), opacity: opacity, id: "tableYAxis1"});
+  $("#tableYAxis1").qtip({content: "new Plottable.Axis.Linear(yScale1, \"left\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  barPlot0.foreground().append("rect")
+                       .attr({fill: colorScale.range()[3], width: barPlot0.width(), height: barPlot0.height(), opacity: opacity, id: "tableBarPlot0"});
+  $("#tableBarPlot0").qtip({content: "new Plottable.Plot.Bar(xScale, yScale0)", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  barPlot1.foreground().append("rect")
+                       .attr({fill: colorScale.range()[4], width: barPlot1.width(), height: barPlot1.height(), opacity: opacity, id: "tableBarPlot1"});
+  $("#tableBarPlot1").qtip({content: "new Plottable.Plot.Bar(xScale, yScale1)", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+
+  // Labels don't take up their entire cell
+  d3.select("#plot-table").append("rect")
+                          .attr({x: yLabel0._xOrigin, y: yAxis0._yOrigin, width: yLabel0.width(), height: yAxis0.height(), fill: colorScale.range()[5], opacity: opacity, id: "tableYLabel0"});
+  $("#tableYLabel0").qtip({content: "new Plottable.Component.Label(\"Top\", \"right\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  d3.select("#plot-table").append("rect")
+                          .attr({x: yLabel1._xOrigin, y: yAxis1._yOrigin, width: yLabel1.width(), height: yAxis1.height(), fill: colorScale.range()[6], opacity: opacity, id: "tableYLabel1"});
+  $("#tableYLabel1").qtip({content: "new Plottable.Component.Label(\"Bottom\", \"left\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  d3.select("#plot-table").append("rect")
+                          .attr({x: xAxis._xOrigin, y: xLabel._yOrigin, width: xAxis.width(), height: xLabel.height(), fill: colorScale.range()[7], opacity: opacity, id: "tableXLabel"});
+  $("#tableXLabel").qtip({content: "new Plottable.Component.Label(\"Categories\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+  d3.select("#plot-table").append("rect")
+                          .attr({x: xAxis._xOrigin, y: masterLabel._yOrigin, width: xAxis.width(), height: masterLabel.height(), fill: colorScale.range()[8], opacity: opacity, id: "tableTitleLabel"});
+  $("#tableTitleLabel").qtip({content: "new Plottable.Component.TitleLabel(\"MasterLabel\")", position: { my: "bottom middle", at: "top middle" }, style: {classes: "qtip-dark"}});
+
+//Attach tooltips with qTip2 (which uses the "title" attribute by default)
+  $("#plot-table").qtip({
     position : {
       my : "bottom middle",
       at : "top middle"

--- a/components/index.html
+++ b/components/index.html
@@ -20,13 +20,13 @@ Below are a variety of components you can choose from to place onto your Plottab
     <div class="col-md-12">
       <h2>Plots</h2>
       <h3>Bar Plot</h3>
-      <svg id="barPlot" height="250" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Plot.Bar(xScale, yScale, true)'></svg>
+      <svg id="barPlot" height="250" title='new Plottable.Plot.Bar(xScale, yScale, true)'></svg>
       <h3>Line Plot</h3>
-      <svg id="linePlot" height="250" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Plot.Line(xScale, yScale)'></svg>
+      <svg id="linePlot" height="250" title='new Plottable.Plot.Line(xScale, yScale)'></svg>
       <h3>Area Plot</h3>
-      <svg id="areaPlot" height="250" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Plot.Area(xScale, yScale)'></svg>
+      <svg id="areaPlot" height="250" title='new Plottable.Plot.Area(xScale, yScale)'></svg>
       <h3>Scatter</h3>
-      <svg id="scatterPlot" height="250" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Plot.Scatter(xScale, yScale)'></svg>
+      <svg id="scatterPlot" height="250" title='new Plottable.Plot.Scatter(xScale, yScale)'></svg>
     </div>
   </div>
 
@@ -34,11 +34,11 @@ Below are a variety of components you can choose from to place onto your Plottab
     <div class="col-md-12">
       <h2>Axes</h2>
       <h3>Numeric Axis</h3>
-      <svg id="numericAxis" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Axis.Numeric(xScale, "bottom")'></svg>
+      <svg id="numericAxis" height="50" title='new Plottable.Axis.Numeric(xScale, "bottom")'></svg>
       <h3>Category Axis</h3>
-      <svg id="categoryAxis" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Axis.Category(xScale, "bottom")'></svg>
+      <svg id="categoryAxis" height="50" title='new Plottable.Axis.Category(xScale, "bottom")'></svg>
       <h3>Time Axis</h3>
-      <svg id="timeAxis" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Axis.Time(xScale, "bottom")'></svg>
+      <svg id="timeAxis" height="50" title='new Plottable.Axis.Time(xScale, "bottom")'></svg>
     </div>
   </div>
 
@@ -46,16 +46,16 @@ Below are a variety of components you can choose from to place onto your Plottab
     <div class="col-md-12">
       <h2>Labels</h2>
       <h3>Regular Label</h3>
-      <svg id="label" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Component.Label("Hello world!")'></svg>
+      <svg id="label" height="50" title='new Plottable.Component.Label("Hello world!")'></svg>
       <h3>Title Label</h3>
-      <svg id="titleLabel" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Component.TitleLabel("Hello world!")'></svg>
+      <svg id="titleLabel" height="50" title='new Plottable.Component.TitleLabel("Hello world!")'></svg>
     </div>
   </div>
 
   <div class="row component-group">
     <div class="col-md-12">
       <h2>Legends</h2>
-      <svg id="legend" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Component.Legend(colorScale)'></svg>
+      <svg id="legend" height="50" title='new Plottable.Component.Legend(colorScale)'></svg>
     </div>
   </div>
 </div>

--- a/components/index.html
+++ b/components/index.html
@@ -2,6 +2,9 @@
 layout  : subpage
 page_id : page-components
 ---
+
+<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/bower_components/qtip2/jquery.qtip.css">
+<script src="{{ site.baseurl }}/bower_components/qtip2/jquery.qtip{{ site.minifiedSuffix }}.js"></script>
 <div class="container">
   <h2>The Component List</h2>
 The best way to think about Plottable that you will not be rendering plots, but you will be rendering components or tables of components.  Even a plot is considered a component!<br><br>
@@ -17,14 +20,13 @@ Below are a variety of components you can choose from to place onto your Plottab
     <div class="col-md-12">
       <h2>Plots</h2>
       <h3>Bar Plot</h3>
-      <div border="2px solid"><svg id="barPlot" height="250"></svg></div>
-
+      <svg id="barPlot" height="250" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Plot.Bar(xScale, yScale, true)'></svg>
       <h3>Line Plot</h3>
-      <svg id="linePlot" height="250"></svg>
+      <svg id="linePlot" height="250" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Plot.Line(xScale, yScale)'></svg>
       <h3>Area Plot</h3>
-      <svg id="areaPlot" height="250"></svg>
+      <svg id="areaPlot" height="250" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Plot.Area(xScale, yScale)'></svg>
       <h3>Scatter</h3>
-      <svg id="scatterPlot" height="250"></svg>
+      <svg id="scatterPlot" height="250" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Plot.Scatter(xScale, yScale)'></svg>
     </div>
   </div>
 
@@ -32,11 +34,11 @@ Below are a variety of components you can choose from to place onto your Plottab
     <div class="col-md-12">
       <h2>Axes</h2>
       <h3>Numeric Axis</h3>
-      <svg id="numericAxis" height="50"></svg>
+      <svg id="numericAxis" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Axis.Numeric(xScale, "bottom")'></svg>
       <h3>Category Axis</h3>
-      <svg id="categoryAxis" height="50"></svg>
+      <svg id="categoryAxis" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Axis.Category(xScale, "bottom")'></svg>
       <h3>Time Axis</h3>
-      <svg id="timeAxis" height="50"></svg>
+      <svg id="timeAxis" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Axis.Time(xScale, "bottom")'></svg>
     </div>
   </div>
 
@@ -44,16 +46,16 @@ Below are a variety of components you can choose from to place onto your Plottab
     <div class="col-md-12">
       <h2>Labels</h2>
       <h3>Regular Label</h3>
-      <svg id="label" height="50"></svg>
+      <svg id="label" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Component.Label("Hello world!")'></svg>
       <h3>Title Label</h3>
-      <svg id="titleLabel" height="50"></svg>
+      <svg id="titleLabel" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Component.TitleLabel("Hello world!")'></svg>
     </div>
   </div>
 
   <div class="row component-group">
     <div class="col-md-12">
       <h2>Legends</h2>
-      <svg id="legend" height="50"></svg>
+      <svg id="legend" height="50" title='<strong class="tooltip-title">Code</strong><br>new Plottable.Component.Legend(colorScale)'></svg>
     </div>
   </div>
 </div>
@@ -77,5 +79,16 @@ window.onload = function() {
   titleLabel("Hello world!", "horizontal").renderTo("#titleLabel");
 
   legend().renderTo("#legend");
+
+  //Attach tooltips with qTip2 (which uses the "title" attribute by default)
+  $("svg").qtip({
+    position : {
+      my : "bottom middle",
+      at : "top middle"
+    },
+    style : {
+      classes : "qtip-dark"
+    }
+  });
 }
 </script>

--- a/components/index.html
+++ b/components/index.html
@@ -10,7 +10,7 @@ page_id : page-components
 The best way to think about Plottable that you will not be rendering plots, but you will be rendering components or tables of components.  Even a plot is considered a component!<br><br>
 By thinking in this manner, one can imagine that any component can be dropped into any cell of a table, meaning you have flexibility on where components go in relation to other components.<br><br>
 
-Below are some of the components you can choose from to place onto your Plottable tables.
+Below are a variety of components you can choose from to place onto your Plottable table.
 </div>
 
 

--- a/components/index.html
+++ b/components/index.html
@@ -5,6 +5,13 @@ page_id : page-components
 
 <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/bower_components/qtip2/jquery.qtip.css">
 <script src="{{ site.baseurl }}/bower_components/qtip2/jquery.qtip{{ site.minifiedSuffix }}.js"></script>
+<style>
+.qtip-dark {
+  font-size: 20px;
+  max-width: 700px;
+}
+</style>
+
 <div class="container">
   <h2>The Component List</h2>
 The best way to think about Plottable that you will not be rendering plots, but you will be rendering components or tables of components.  Even a plot is considered a component!<br><br>


### PR DESCRIPTION
Revamping the Components Tab.

Now there is some text at the top expressing our intent to treat our objects as components to place onto a table, and then listing each component with a label along with a summary snippet of how the component is generated via tooltip.

Feel free to iterate and criticize, especially for the text section/feel of the page.

![screen shot 2015-01-08 at 6 16 06 pm](https://cloud.githubusercontent.com/assets/1448299/5674619/7746af58-9762-11e4-8fdc-a12f6a8d71c6.png)
